### PR TITLE
Added entry to the addin registry and fixed a typo in Readme.md

### DIFF
--- a/MarkdownMonsterAddinRegistry.json
+++ b/MarkdownMonsterAddinRegistry.json
@@ -61,5 +61,12 @@
 		"summary": "Open a Console Terminal Window of your choice and keep it 'pinned' to the bottom of the Markdown Monster Application Window.",
 		"author": "© Rick Strahl, West Wind Technologies",
 		"gitUrl": "https://github.com/RickStrahl/Console-MarkdownMonster-Addin/master"
+	}	,
+	{
+		"id": "TextGenerator",
+		"name": "Text Generator",
+		"summary": "Generate random text to be inserted in the current document using an implementation of Lorem Ipsum. Requires MarkdownMonster version 2.",
+		"author": "© Joe McLain, Digital Writing",
+		"gitUrl": "https://github.com/joemclain/MMTextGeneratorAddin/master"
 	}	
 ]

--- a/Readme.md
+++ b/Readme.md
@@ -3,7 +3,7 @@
 ![](./MarkdownMonsterAddins_Icon.png)
 
 ### Publish your Markdown Monster Addins here
-This repository is an Addin Registry for addins for the [Markdown Monster Markdown Editor for Windows](https://markdownmonster.west-wind.com) which is contained in `MarkdownMonsterAddinRegistry.json`.  arkdown MOnster's addin manager accesses this file to display addin listings and then dynamically loads the individual addin information from their respective Github repositories.
+This repository is an Addin Registry for addins for the [Markdown Monster Markdown Editor for Windows](https://markdownmonster.west-wind.com) which is contained in `MarkdownMonsterAddinRegistry.json`.  Markdown Monster's addin manager accesses this file to display addin listings and then dynamically loads the individual addin information from their respective Github repositories.
 
 This repository provides a list of available add-ins that are hosted via Git/Github and can be installed via the registry from within Markdown Monster via the [MarkdownMonsterAddinRegistry.json file](https://github.com/RickStrahl/MarkdownMonsterAddinsRegistry/blob/master/MarkdownMonsterAddinRegistry.json). You can publish your own add-ins that follow the addin guidelines in this document and publish it in this registry via pull request.
 


### PR DESCRIPTION
> Added "Text Generator" entry into MarkdownMonsterAddinRegistry.json; fixed several typos in the first paragraph of the Readme.md file.

"Text Generator" is a random text generator using Lorem Ipsum text which allows (as the name suggest), the insertion of random chunks of text into a MarkdownMonster document. Not a huge call for an addin that does this sort of thing, but I needed it for template documents, others might have similar uses. (I also wrote it to get reacquainted with the MM addin api.)

I also fixed a typo in the first paragraph of the readme.md file where "Markdown Monster" was mangled.